### PR TITLE
Enable the ability to save the RRDN model

### DIFF
--- a/ISR/models/rrdn.py
+++ b/ISR/models/rrdn.py
@@ -144,8 +144,6 @@ class RRDN(ImageModel):
     
     def _pixel_shuffle(self, input_layer):
         """ PixelShuffle implementation of the upscaling part. """
-        scale = self.scale 
-
         x = Conv2D(
             self.c_dim * self.scale ** 2,
             kernel_size=3,
@@ -154,7 +152,7 @@ class RRDN(ImageModel):
             name='PreShuffle',
         )(input_layer)
 
-        return PixelShuffle(scale)(x)
+        return PixelShuffle(self.scale)(x)
     
     def _build_rdn(self):
         LR_input = Input(shape=(self.patch_size, self.patch_size, 3), name='LR_input')

--- a/ISR/models/rrdn.py
+++ b/ISR/models/rrdn.py
@@ -131,17 +131,19 @@ class RRDN(ImageModel):
         
         # SUGGESTION: MAKE BETA LEARNABLE
         x = input_layer
+        beta = self.beta
         
         for d in range(1, self.D + 1):
             LFF = self._dense_block(x, d, t)
-            LFF_beta = Lambda(lambda x: x * self.beta)(LFF)
+            LFF_beta = Lambda(lambda x: x * beta)(LFF)
             x = Add(name='LRL_%d_%d' % (t, d))([x, LFF_beta])
-        x = Lambda(lambda x: x * self.beta)(x)
+        x = Lambda(lambda x: x * beta)(x)
         x = Add(name='RRDB_%d_out' % (t))([input_layer, x])
         return x
     
     def _pixel_shuffle(self, input_layer):
         """ PixelShuffle implementation of the upscaling part. """
+        scale = self.scale
         
         x = Conv2D(
             self.c_dim * self.scale ** 2,
@@ -151,7 +153,7 @@ class RRDN(ImageModel):
             name='PreShuffle',
         )(input_layer)
         return Lambda(
-            lambda x: tf.nn.depth_to_space(x, block_size=self.scale, data_format='NHWC'),
+            lambda x: tf.nn.depth_to_space(x, block_size=scale, data_format='NHWC'),
             name='PixelShuffle',
         )(x)
     

--- a/ISR/models/rrdn.py
+++ b/ISR/models/rrdn.py
@@ -145,7 +145,6 @@ class RRDN(ImageModel):
     def _pixel_shuffle(self, input_layer):
         """ PixelShuffle implementation of the upscaling part. """
         scale = self.scale 
-        # print('_pixel_shuffle method')
 
         x = Conv2D(
             self.c_dim * self.scale ** 2,
@@ -183,7 +182,6 @@ class RRDN(ImageModel):
         # Global Residual Learning
         GRL = Add(name='GRL')([post_blocks, pre_blocks])
         # Upscaling
-        # print('single pixel shuffle')
         PS = self._pixel_shuffle(GRL)
         # Compose SR image
         SR = Conv2D(

--- a/ISR/models/rrdn.py
+++ b/ISR/models/rrdn.py
@@ -131,7 +131,6 @@ class RRDN(ImageModel):
         
         # SUGGESTION: MAKE BETA LEARNABLE
         x = input_layer
-
         for d in range(1, self.D + 1):
             LFF = self._dense_block(x, d, t)
             LFF_beta = MultiplyBeta(self.beta)(LFF)
@@ -139,8 +138,6 @@ class RRDN(ImageModel):
         x = MultiplyBeta(self.beta)(x)
         x = Add(name='RRDB_%d_out' % (t))([input_layer, x])
         return x
-
-
     
     def _pixel_shuffle(self, input_layer):
         """ PixelShuffle implementation of the upscaling part. """


### PR DESCRIPTION
[Pursuant to this comment thread](https://github.com/idealo/image-super-resolution/issues/114), enables the ability to save the RRDN model.

I tried to implement a `get_config` but was unsuccessful, so I copied the implementation by @gkrislara. I'm using this code to save an RRDN model successfully.

Sample code for saving:

```
from ISR.models import RRDN
model = RRDN(weights='gans')
model.model.save('./image-super-resolution-gans.h5')
```