### PR TITLE
fixed bug where h5py downloads incompatible version of cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description='Image Super Resolution',
     long_description=long_description,
     license='Apache 2.0',
-    install_requires=['imageio', 'numpy', 'tensorflow==2.*', 'tqdm', 'pyaml', 'h5py==2.10.0'],
+    install_requires=['imageio', 'numpy', 'tensorflow==2.*', 'tqdm', 'pyaml', 'cython', 'h5py==2.10.0'],
     extras_require={
         'tests': ['pytest==4.3.0', 'pytest-cov==2.6.1'],
         'docs': ['mkdocs==1.0.4', 'mkdocs-material==4.0.2'],


### PR DESCRIPTION
h5py needs cython to compile. **When cython is not installed** on the machine it will automatically download cython to compile itself. Currently, the version of cython that it downloads is 3.0a1, which is unable to compile h5py. This bug is with h5py/cython and not directly stemming from image-super-resolution, but it is causing bugs downstream in this project. To fix this issue you just need to make sure that cython is installed on the machine first (with a compatible version). It would be good practice to include a specific version range in setup.py, but for now this works.


[guy on h5py repo issues section discussing this solution](https://github.com/h5py/h5py/issues/1533#issuecomment-615227322)